### PR TITLE
Fix Directory Traversal

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -26,9 +26,11 @@ async def on_member_remove(self, member):
     await channel.send(f'{member} has left the server. :pensive:')
 
 @client.event
-async def on_commmand_error(self, ctx, error):
-    if isinstance(error, commands.MissingRequiredArgument):
+async def on_command_error(ctx, error):
+    if isinstance(error, commands.errors.MissingRequiredArgument):
         await ctx.send('Please give all the arguments.')
+    elif isinstance(error,commands.errors.BadArgument):
+        await ctx.send("Conversion of arguments failed.")
     print(f"ERROR: {error}")
 
 # @client.command(brief = 'Reloads cog.', description = 'Do ";reload cog".')

--- a/cogs/maths.py
+++ b/cogs/maths.py
@@ -16,7 +16,8 @@ class Maths(commands.Cog):
     self.client = client
 
   @commands.command(brief = "Generate Junior Mathematical Competition problem, usage: .jmc <year>")
-  async def jmc(self, ctx, year): # from years 2004 - 2018
+  async def jmc(self, ctx, year: int): # from years 2004 - 2018
+    year = str(year)
     try:
       allProblems = os.listdir("MATHS-IMAGES/junior/" + year)
       problem = random.choice(allProblems)
@@ -25,7 +26,8 @@ class Maths(commands.Cog):
       await ctx.send("Junior Mathematical Competition problems only available from 2004 to 2018")
 
   @commands.command(brief = "Generate Intermediate Mathematical Competition problem, usage: .imc <year>")
-  async def imc(self, ctx, year): # from years 2004 - 2018
+  async def imc(self, ctx, year: int): # from years 2004 - 2018
+    year = str(year)
     try:
       allProblems = os.listdir("MATHS-IMAGES/intermediate/" + year)
       problem = random.choice(allProblems)
@@ -34,7 +36,8 @@ class Maths(commands.Cog):
       await ctx.send("Intermediate Mathematical Competition problems only available from 2004 to 2018")
   
   @commands.command(brief = "Generate Senior Mathematical Competition problem, usage: .smc <year>")
-  async def smc(self, ctx, year): # from years 2005 - 2018
+  async def smc(self, ctx, year: int): # from years 2005 - 2018
+    year = str(year)
     try:
       allProblems = os.listdir("MATHS-IMAGES/senior/" + year)
       problem = random.choice(allProblems)


### PR DESCRIPTION
In the maths cog, a few of the commands designed to grab files for JMC/IMC/SMC questions were vulnerable to directory traversal, as demonstrated below. This could be used to retrieve credentials and bot tokens. This should fix these issues by requiring integer years, so "../" and the like cannot be used.

<img width="868" alt="Screenshot 2020-10-03 at 10 27 41" src="https://user-images.githubusercontent.com/62653826/94988152-1361a680-0563-11eb-8377-bda46fd495b2.png">
