### PR TITLE
Move presence from on_ready to bot instantiation

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -3,7 +3,7 @@ from discord.ext import commands
 from discord.ext.commands import has_permissions, MissingPermissions
 import json
 
-client = commands.Bot(command_prefix=".")
+client = commands.Bot(command_prefix=".", status=discord.Status.online, activity=discord.Game("with the on and off switch"))
 client.remove_command("help")
 
 with open("creds.json", "r") as creds:
@@ -14,9 +14,6 @@ with open("creds.json", "r") as creds:
 @client.event
 async def on_ready():
     print("The Jambot is here. Hello.")
-    await client.change_presence(
-        status=discord.Status.online, activity=discord.Game("with the on and off switch")
-    )
 
 
 @client.event


### PR DESCRIPTION
Just a small thing which has been bugging me, presence shouldn't be updated in the `on_ready()` event.

Relevant info from discord.py:

> Don't `change_presence` (or make API calls) in `on_ready` within your Bot or Client.
> Discord has a high chance to completely disconnect you during the READY or GUILD_CREATE events (1006 close code) and there is nothing you can do to prevent it.
> 
> Instead set the `activity` and `status` kwargs in the constructor of these Classes.
> 
> ```py
> bot = commands.Bot(command_prefix="!", activity=..., status=...)
> ```
> 
> As noted in the docs, `on_ready` is also triggered *multiple* times, not just once. 